### PR TITLE
Fixing GKE deployment

### DIFF
--- a/bigtable-autoscaler-service.yaml
+++ b/bigtable-autoscaler-service.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     app: bigtable-autoscaler
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bigtable-autoscaler 


### PR DESCRIPTION
With the Kubernetes upgrade to 1.16, the Deployment type no longer exists in the extensions/v1beta1 api group. It is now in the apps api group. That meant that the deployment was working in QA (Kubernetes 1.15), but not in PROD (Kubernetes 1.16). This change fixes the prod deployment.